### PR TITLE
APM-3954 Add mock-jwks to all envs.

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -34,7 +34,19 @@ extends:
       - environment: internal-dev
         jinja_templates:
           TESTING_ENDPOINTS: true
+      - environment: internal-dev-sandbox
+        jinja_templates:
+          TESTING_ENDPOINTS: true
       - environment: internal-qa
+        jinja_templates:
+          TESTING_ENDPOINTS: true
+      - environment: internal-qa-sandbox
+        jinja_templates:
+          TESTING_ENDPOINTS: true
+      - environment: ref
+        jinja_templates:
+          TESTING_ENDPOINTS: true
+      - environment: dev
         jinja_templates:
           TESTING_ENDPOINTS: true
       - environment: int

--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -1,9 +1,12 @@
 APIGEE_ENVIRONMENTS:
   - name: internal-dev
+  - name: internal-dev-sandbox
   - name: internal-qa
+  - name: internal-qa-sandbox
+  - name: ref
+  - name: dev
   - name: sandbox
   - name: int
-
 ---
 
 meta:
@@ -27,7 +30,7 @@ apigee:
       - name: ratelimit
         value: 300pm
       description: example description
-      displayName: mock-jwks (Internal Development Environment)
+      displayName: mock-jwks ({{ env.name }} Environment)
       environments:
       - {{ env.name }}
       name: mock-jwks-{{ env.name }}


### PR DESCRIPTION
Since pytest-nhsd-apim seems to require it now